### PR TITLE
Starting Twirl update.

### DIFF
--- a/chapter07-twirl/project/build.properties
+++ b/chapter07-twirl/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.5

--- a/chapter07-twirl/project/build.scala
+++ b/chapter07-twirl/project/build.scala
@@ -35,9 +35,7 @@ object Chapter06Build extends Build {
       ),
       browseTask
     )
-  )
-
-  project.enablePlugins(SbtTwirl) // TODO: this doesn't seem to quite cut it. What's missing? Any ideas, Stefan?
+  ).enablePlugins(SbtTwirl) 
 
   val browse = TaskKey[Unit]("browse", "open web browser to localhost on container:port")
   val browseTask = browse <<= (streams, port in container.Configuration) map { (streams, port) =>

--- a/chapter07-twirl/project/build.scala
+++ b/chapter07-twirl/project/build.scala
@@ -1,6 +1,6 @@
 import sbt._
 import Keys._
-import twirl.sbt.TwirlPlugin._
+import play.twirl.sbt.SbtTwirl
 
 object Chapter06Build extends Build {
   val Organization = "org.scalatra"
@@ -20,7 +20,7 @@ object Chapter06Build extends Build {
   lazy val project = Project (
     Name,
     file("."),
-    settings = Defaults.defaultSettings ++ webSettings ++ Twirl.settings ++ Seq(
+    settings = webSettings ++ Seq(
       organization := Organization,
       name := Name,
       version := Version,
@@ -36,6 +36,8 @@ object Chapter06Build extends Build {
       browseTask
     )
   )
+
+  project.enablePlugins(SbtTwirl) // TODO: this doesn't seem to quite cut it. What's missing? Any ideas, Stefan?
 
   val browse = TaskKey[Unit]("browse", "open web browser to localhost on container:port")
   val browseTask = browse <<= (streams, port in container.Configuration) map { (streams, port) =>

--- a/chapter07-twirl/project/plugins.sbt
+++ b/chapter07-twirl/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.mojolly.scalate" % "xsbt-scalate-generator" % "0.4.2")
 
 addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.3.2")
 
-addSbtPlugin("io.spray" % "sbt-twirl" % "0.6.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.0.4")


### PR DESCRIPTION
Hey @dozed or @rossabaker, it appears that the book is now out of date in the Twirl section, as Play have taken Twirl back in-house and released a 1.x which doesn't depend on the outdated version of sbt. 

I've tried an upgrade but it doesn't seem to work all the way for me. The method `html` isn't found when rendering templates. I don't think it should be necessary to set a custom template path, do you have any idea what to do here? I've never used Twirl myself. 

This pull request is as far as I've got with it. Out of interest, I took a look at the Gitbucket source code, and it has the same problem for me, so maybe there's something else in my environment that's missing. 

I've made changes to the book source, eliminating the part about Twirl using an outdated sbt, but we'll need to get this code example working and ensure that the Twirl config explanation in the book matches with whatever setup works in this feature branch.